### PR TITLE
Restructure package to follow Python conventions

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,62 @@
+# Testing the Package Structure
+
+This document provides instructions for testing the package structure to ensure imports work correctly.
+
+## Testing Import Functionality
+
+After restructuring the package, it's important to verify that imports work as expected. You can use the provided `test_imports.py` script to check if the package structure is correctly set up.
+
+### Running the Test Script
+
+To run the test script:
+
+```bash
+# From the repository root directory
+python test_imports.py
+```
+
+If the package structure is correctly set up, you should see output similar to:
+
+```
+Testing imports...
+✅ Successfully imported LlmAgent
+✅ Successfully imported enable_tracing
+✅ Successfully created an LlmAgent instance: TestAgent
+✅ Successfully called enable_tracing
+
+All imports and basic functionality tests passed!
+```
+
+### Manual Testing
+
+You can also test the imports manually in a Python interpreter:
+
+```python
+# Start Python interpreter
+python
+
+# Try importing from the package
+from google.adk import LlmAgent
+from google.adk import enable_tracing
+
+# If no errors occur, the package structure is correct
+```
+
+## Installing the Package in Development Mode
+
+For development, you can install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+This will install the package while allowing you to make changes to the code without needing to reinstall.
+
+## Troubleshooting
+
+If you encounter import errors:
+
+1. Make sure you're running the script from the repository root directory
+2. Verify that all `__init__.py` files are present in the package directories
+3. Check that `setup.py` includes the correct package configuration
+4. Try installing the package in development mode as described above

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -1,0 +1,1 @@
+"""Google package namespace."""

--- a/google/adk/__init__.py
+++ b/google/adk/__init__.py
@@ -1,0 +1,10 @@
+"""Google Agent Development Kit (ADK) package.
+
+This package provides the core functionality for building AI agents using Google's
+Agent Development Kit framework.
+"""
+
+from .llm_agent import LlmAgent
+from .tracing import enable_tracing
+
+__all__ = ["LlmAgent", "enable_tracing"]

--- a/google/adk/llm_agent.py
+++ b/google/adk/llm_agent.py
@@ -1,0 +1,59 @@
+"""LlmAgent: Base class for building AI agents with LLM capabilities."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
+class LlmAgent:
+    """Base class for building AI agents with LLM capabilities.
+    
+    This class provides the core functionality for creating agents that can
+    use large language models to process and respond to user inputs.
+    """
+    
+    def __init__(
+        self,
+        name: str,
+        tools: List[Any] = None,
+        system_prompt: str = "",
+        memory: Any = None,
+    ) -> None:
+        """Initialize a new LlmAgent.
+        
+        Args:
+            name: The name of the agent.
+            tools: A list of tools the agent can use.
+            system_prompt: The system prompt that defines the agent's behavior.
+            memory: Optional memory system for the agent.
+        """
+        self.name = name
+        self.tools = tools or []
+        self.system_prompt = system_prompt
+        self.memory = memory
+        
+    async def process(self, message: Any, **kwargs) -> Dict[str, Any]:
+        """Process a user message and return a response.
+        
+        Args:
+            message: The user message to process.
+            **kwargs: Additional keyword arguments.
+            
+        Returns:
+            A dictionary containing the agent's response and any additional information.
+        """
+        raise NotImplementedError("Subclasses must implement process method")
+    
+    async def run_tool(self, tool_name: str, **tool_args) -> Any:
+        """Run a tool with the given arguments.
+        
+        Args:
+            tool_name: The name of the tool to run.
+            **tool_args: Arguments to pass to the tool.
+            
+        Returns:
+            The result of running the tool.
+        """
+        for tool in self.tools:
+            if tool.__name__ == tool_name:
+                return await tool.call(**tool_args)
+        
+        raise ValueError(f"Tool {tool_name} not found")

--- a/google/adk/tracing.py
+++ b/google/adk/tracing.py
@@ -1,0 +1,45 @@
+"""Tracing utilities for ADK agents."""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Literal, Optional, Union
+
+# Configure basic logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+
+def enable_tracing(
+    output: Union[Literal["stdout"], str, None] = None,
+    level: int = logging.INFO,
+) -> None:
+    """Enable tracing for ADK agents.
+    
+    Args:
+        output: Where to send trace output. Can be "stdout" for console output,
+            a file path string, or None to disable tracing.
+        level: The logging level to use.
+    """
+    logger = logging.getLogger("google.adk")
+    logger.setLevel(level)
+    
+    # Clear existing handlers
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+    
+    if output == "stdout":
+        handler = logging.StreamHandler(sys.stdout)
+    elif output is not None:
+        handler = logging.FileHandler(output)
+    else:
+        # No output specified, return without adding handlers
+        return
+    
+    handler.setLevel(level)
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    
+    logger.info("Tracing enabled for ADK agents")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="instabids-a2a",
+    version="0.1.0",
+    description="InstaBids A2A Implementation",
+    author="JustinAIDistuptors",
+    packages=find_packages(include=["google", "google.*"]),
+    install_requires=[
+        # Add your dependencies here
+    ],
+    python_requires=">=3.9",
+)

--- a/test_imports.py
+++ b/test_imports.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Test script to verify the package structure and imports."""
+
+import sys
+import os
+
+# Add the current directory to the Python path
+sys.path.insert(0, os.path.abspath('.'))
+
+try:
+    print("Testing imports...")
+    
+    # Test importing LlmAgent
+    from google.adk import LlmAgent
+    print("✅ Successfully imported LlmAgent")
+    
+    # Test importing enable_tracing
+    from google.adk import enable_tracing
+    print("✅ Successfully imported enable_tracing")
+    
+    # Test creating an LlmAgent instance
+    agent = LlmAgent(name="TestAgent", system_prompt="This is a test")
+    print(f"✅ Successfully created an LlmAgent instance: {agent.name}")
+    
+    # Test enable_tracing function
+    enable_tracing("stdout")
+    print("✅ Successfully called enable_tracing")
+    
+    print("\nAll imports and basic functionality tests passed!")
+    
+except ImportError as e:
+    print(f"❌ Import error: {e}")
+    print("\nThe package structure might not be set up correctly.")
+    sys.exit(1)
+except Exception as e:
+    print(f"❌ Error: {e}")
+    sys.exit(1)


### PR DESCRIPTION
This PR restructures the project to follow Python's package structure conventions and ensure proper imports.

## Problem
The current structure has a directory named `google.adk` (with a dot in the folder name), which breaks Python's import rules and collides with the real `google` namespace that many libraries install.

When trying to import:
```python
from google import adk  # fails
from google.adk import LlmAgent  # fails
```

At runtime, if another package (e.g., google-auth, google-cloud-storage) has already inserted `google` into `sys.modules`, Python ignores the `google.adk` folder, producing "module not found" errors.

## Solution
This PR implements the recommended fix: creating a proper namespace package structure.

### Changes:
- Created proper directory structure:
  ```
  google/
   ├── __init__.py
   └── adk/
       ├── __init__.py
       ├── llm_agent.py
       └── tracing.py
  ```
- Created `setup.py` with proper package configuration using `find_packages(include=["google", "google.*"])`
- Implemented `LlmAgent` class in `google/adk/llm_agent.py`
- Implemented tracing utilities in `google/adk/tracing.py`

### Benefits:
- Keeps canonical imports (`from google.adk import LlmAgent`)
- Plays nicely with other Google libraries
- Follows Python packaging best practices

## Testing
After merging, verify with:
```bash
pip install -e .
python -c "from google.adk import LlmAgent, enable_tracing; print('OK')"
```